### PR TITLE
fix(migration): use simple quote for values on insert;

### DIFF
--- a/migrations/Version20250201105755.php
+++ b/migrations/Version20250201105755.php
@@ -22,7 +22,7 @@ final class Version20250201105755 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE TABLE "user" (id SERIAL NOT NULL, email VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_IDENTIFIER_EMAIL ON "user" (email)');
-        $this->addSql('INSERT INTO public."user" (id, email, roles, password) VALUES (DEFAULT, "test@test.com", "[]", "$2y$13$og2KfSgYeEYZqAJyhRkIeeXcGvBaPbln4VM6bxx8byfMqNSxSQMzS")');
+        $this->addSql('INSERT INTO public."user" (id, email, roles, password) VALUES (DEFAULT, \'test@test.com\', \'[]\', \'$2y$13$og2KfSgYeEYZqAJyhRkIeeXcGvBaPbln4VM6bxx8byfMqNSxSQMzS\')');
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
Hi there !

Following last week's presentation, I am currently testing the demo.

Thanks for that ! It's so useful for understand how it's working. 

While installing the project, I found a small error. Using double quotes to enclose the values ​​to be inserted into the database doesn't seem to match the expected syntax. So I'm proposing this small fix to use single quotes instead.

```
INSERT INTO public."user" (id, email, roles, password) VALUES (DEFAULT, "test@test.com", "[]", "$2y$13$og2KfSgYeEYZqAJyhRkIeeXcGvBaPbln4VM6bxx8byfMqNSxSQMzS");
ERROR:  column "test@test.com" does not exist
LINE 1: ...er" (id, email, roles, password) VALUES (DEFAULT, "test@test...
```

